### PR TITLE
feat: add support for routers

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,10 +79,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -99,7 +99,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -271,5 +271,5 @@ packages:
     source: hosted
     version: "3.0.3"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/utils/utils_common.dart
+++ b/lib/src/utils/utils_common.dart
@@ -1,0 +1,7 @@
+bool xnor(List<bool> conditions) {
+  // Count the number of `true` values in the list.
+  int trueCount = conditions.where((c) => c).length;
+
+  // Return true if all are true or all are false.
+  return trueCount == 0 || trueCount == conditions.length;
+}

--- a/test/src/utils/utils_common_test.dart
+++ b/test/src/utils/utils_common_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_test/src/utils/utils_common.dart';
+
+void main() {
+  group('xnor - ', () {
+    test('All true conditions returns true', () {
+      expect(xnor([true, true, true]), isTrue);
+    });
+
+    test('All false conditions returns true', () {
+      expect(xnor([false, false, false]), isTrue);
+    });
+
+    test('Mixed conditions (some true, some false) returns false', () {
+      expect(xnor([true, false, true]), isFalse);
+      expect(xnor([true, false, false]), isFalse);
+    });
+
+    test('Empty list returns true', () {
+      expect(xnor([]), isTrue);
+    });
+
+    test('Single true condition returns true', () {
+      expect(xnor([true]), isTrue);
+    });
+
+    test('Single false condition returns true', () {
+      expect(xnor([false]), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Hey! 👋 

This PR allows for testing widgets that depend on some kinds of Routers e.g. [go_router](https://pub.dev/packages/go_router). To be precise in one of the projects we use 
```dart
bool _isActive(BuildContext context) => GoRouter.of(context).location == NotificationsPage.routeToPush;
```
in order to check if we are currently on that specific page. Because there is no Router provided in the widget tree the test fails. It's just a single example, but I guess there can be more similar cases for different routers 🤔 

So basically this PR adds an option for using `MaterialApp.router` if someone needs it. Because using `MaterialApp.router` does not have a `child` param we are not able to wrap our widget that we want to test into some additional widgets as e.g. `Provider`. That's why I also added a `wrappers` param which wraps a whole `MaterialApp`.

Let me know what you think and what I should adjust to your requirements. 👌 