### PR TITLE
fix: generating failures for dark/light mode and different languages

### DIFF
--- a/lib/src/local_file_comparator_with_tolerance.dart
+++ b/lib/src/local_file_comparator_with_tolerance.dart
@@ -34,7 +34,6 @@ class LocalFileComparatorWithTolerance extends LocalFileComparator {
             golden.pathSegments.sublist(0, golden.pathSegments.length - 1),
       );
 
-      /// Includes path for dark/light mode and different languages.
       final Uri updatedBasedir =
           basedir.resolve(goldenPathWithoutFile.toString());
 

--- a/lib/src/local_file_comparator_with_tolerance.dart
+++ b/lib/src/local_file_comparator_with_tolerance.dart
@@ -29,7 +29,16 @@ class LocalFileComparatorWithTolerance extends LocalFileComparator {
     }
 
     if (!result.passed) {
-      final error = await generateFailureOutput(result, golden, basedir);
+      final Uri goldenPathWithoutFile = golden.replace(
+        pathSegments:
+            golden.pathSegments.sublist(0, golden.pathSegments.length - 1),
+      );
+
+      /// Includes path for dark/light mode and different languages.
+      final Uri updatedBasedir =
+          basedir.resolve(goldenPathWithoutFile.toString());
+
+      final error = await generateFailureOutput(result, golden, updatedBasedir);
       throw FlutterError(error);
     }
     return result.passed;


### PR DESCRIPTION
Hey! 👋
I've noticed that my failure files were wrongly generated. All of them were generated in the same directory and because all of them (dark/light mode, different languages) had exactly the same filenames they were overridden.

So e.g. I had such a structure
![image](https://github.com/user-attachments/assets/56474669-8e81-4f03-8fd4-d62d54e4a0ee)

instead of that one
![image](https://github.com/user-attachments/assets/95005bb8-ac09-4a3d-9d62-791e2baaa8c4)

This PR fixes that issue and produces the results from the second screenshot.